### PR TITLE
Defined PyLong_AsUnsignedLongLongMask for Python3

### DIFF
--- a/fastrandmodule.c
+++ b/fastrandmodule.c
@@ -61,6 +61,7 @@ static inline uint32_t pcg32_random_bounded_divisionless(uint32_t range) {
 
 #if PY_MAJOR_VERSION >= 3
 #define PyInt_AsLong(x)   PyLong_AsLong(x)
+#define PyInt_AsUnsignedLongLongMask(x) PyLong_AsUnsignedLongLongMask(x)
 #endif
 
  static PyObject*


### PR DESCRIPTION
PyLong_AsUnsignedLongLongMask was not defined so fastrand did not work with Python3.5
Now it seems to work without any issue.